### PR TITLE
GAL-23: Module Listing Page

### DIFF
--- a/frontend/src/app/modules/page.tsx
+++ b/frontend/src/app/modules/page.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import ModuleCard from '@/components/ModuleCard';
+import { Module } from '@/types/module';
+
+export default function ModulesPage() {
+  const router = useRouter();
+  const [modules, setModules] = useState<Module[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchModules = async () => {
+      try {
+        setLoading(true);
+        // Sample data for now. We gotta replace with backend API
+        await new Promise(resolve => setTimeout(resolve, 1000)); 
+        
+        const mockModules: Module[] = [
+          {
+            id: '1',
+            title: 'Phishing Emails',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+          },
+          {
+            id: '2',
+            title: 'Bank Impersonations',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+          },
+          {
+            id: '3',
+            title: 'Charity Scams',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+          },
+          {
+            id: '4',
+            title: 'Computer Tech',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+          },
+          {
+            id: '5',
+            title: 'Fake Survey Scams',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+          },
+          {
+            id: '6',
+            title: 'Government Imposter Scam',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+          },
+        ];
+        
+        setModules(mockModules);
+        setError(null);
+      } catch (err) {
+        setError('Failed to load modules. Please try again later.');
+        console.error('Error fetching modules:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchModules();
+  }, []);
+
+  const handleStartModule = (moduleId: string) => {
+    router.push(`/modules/${moduleId}`);
+  };
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  // Loading State
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="mb-8">
+            <button
+              onClick={handleBack}
+              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Back
+            </button>
+          </div>
+          
+          <h1 className="text-4xl font-bold mb-8 text-center">Pick a module!</h1>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[1, 2, 3, 4, 5, 6].map((i) => (
+              <div key={i} className="bg-white rounded-lg shadow-md p-6 animate-pulse">
+                <div className="w-full h-32 bg-gray-200 rounded-lg mb-4"></div>
+                <div className="h-4 bg-gray-200 rounded w-1/4 mb-2"></div>
+                <div className="h-6 bg-gray-200 rounded w-3/4 mb-2"></div>
+                <div className="h-4 bg-gray-200 rounded w-full mb-4"></div>
+                <div className="h-2 bg-gray-200 rounded w-full mb-4"></div>
+                <div className="h-10 bg-gray-200 rounded w-full"></div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error State
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="mb-8">
+            <button
+              onClick={handleBack}
+              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Back
+            </button>
+          </div>
+          
+          <div className="flex flex-col items-center justify-center min-h-[400px]">
+            <div className="bg-red-50 border-2 border-red-200 rounded-lg p-8 max-w-md text-center">
+              <svg 
+                className="w-16 h-16 text-red-400 mx-auto mb-4" 
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+              >
+                <path 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round" 
+                  strokeWidth={2} 
+                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" 
+                />
+              </svg>
+              <h2 className="text-xl font-bold text-red-800 mb-2">Error Loading Modules</h2>
+              <p className="text-red-600 mb-4">{error}</p>
+              <button
+                onClick={() => window.location.reload()}
+                className="px-6 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+              >
+                Try Again
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty State
+  if (modules.length === 0) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="mb-8">
+            <button
+              onClick={handleBack}
+              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Back
+            </button>
+          </div>
+          
+          <div className="flex flex-col items-center justify-center min-h-[400px]">
+            <div className="bg-yellow-50 border-2 border-yellow-200 rounded-lg p-8 max-w-md text-center">
+              <svg 
+                className="w-16 h-16 text-yellow-400 mx-auto mb-4" 
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+              >
+                <path 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round" 
+                  strokeWidth={2} 
+                  d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" 
+                />
+              </svg>
+              <h2 className="text-xl font-bold text-yellow-800 mb-2">No Modules Available</h2>
+              <p className="text-yellow-700">
+                There are no training modules available at this time. Please check back later!
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Success State - Display Modules
+  return (
+    <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Back Button */}
+        <div className="mb-8">
+          <button
+            onClick={handleBack}
+            className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back
+          </button>
+        </div>
+
+        {/* Page Title */}
+        <h1 className="text-4xl font-bold mb-8 text-center text-gray-800">
+          Pick a module!
+        </h1>
+
+        {/* Module Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {modules.map((module) => (
+            <ModuleCard
+              key={module.id}
+              module={module}
+              onStartModule={handleStartModule}
+            />
+          ))}
+        </div>
+
+        {/* Module Count */}
+        <div className="mt-8 text-center text-gray-600">
+          <p>Showing {modules.length} training module{modules.length !== 1 ? 's' : ''}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/modules/page.tsx
+++ b/frontend/src/app/modules/page.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import ModuleCard from '@/components/ModuleCard';
 import { Module } from '@/types/module';
+import ProtectedRoute from '@/components/ProtectedRoute';
 
-export default function ModulesPage() {
+function ModulesPageContent() {
   const router = useRouter();
   const [modules, setModules] = useState<Module[]>([]);
   const [loading, setLoading] = useState(true);
@@ -92,7 +93,7 @@ export default function ModulesPage() {
           <div className="mb-8">
             <button
               onClick={handleBack}
-              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors cursor-pointer"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -128,7 +129,7 @@ export default function ModulesPage() {
           <div className="mb-8">
             <button
               onClick={handleBack}
-              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors cursor-pointer"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -156,7 +157,7 @@ export default function ModulesPage() {
               <p className="text-red-600 mb-4">{error}</p>
               <button
                 onClick={() => window.location.reload()}
-                className="px-6 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                className="px-6 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors cursor-pointer"
               >
                 Try Again
               </button>
@@ -175,7 +176,7 @@ export default function ModulesPage() {
           <div className="mb-8">
             <button
               onClick={handleBack}
-              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+              className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors cursor-pointer"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -218,7 +219,7 @@ export default function ModulesPage() {
         <div className="mb-8">
           <button
             onClick={handleBack}
-            className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors cursor-pointer"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -249,5 +250,13 @@ export default function ModulesPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function ModulesPage() {
+  return (
+    <ProtectedRoute>
+      <ModulesPageContent />
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/components/ModuleCard.tsx
+++ b/frontend/src/components/ModuleCard.tsx
@@ -69,7 +69,7 @@ export default function ModuleCard({ module, onStartModule }: ModuleCardProps) {
       {/* Start/Continue Button */}
       <button
         onClick={() => onStartModule(module.id)}
-        className="w-full py-2 rounded-md bg-[#f1bb79] shadow-[3px_3px_0_#d09a58] font-bold text-lg hover:bg-[#f1bb79]/85 transition-colors flex items-center justify-center gap-2"
+        className="w-full py-2 rounded-md bg-[#f1bb79] shadow-[3px_3px_0_#d09a58] font-bold text-lg hover:bg-[#f1bb79]/85 transition-colors flex items-center justify-center gap-2 cursor-pointer"
       >
         {buttonText}
         <svg 

--- a/frontend/src/components/ModuleCard.tsx
+++ b/frontend/src/components/ModuleCard.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Module } from '@/types/module';
+
+interface ModuleCardProps {
+  module: Module;
+  onStartModule: (moduleId: string) => void;
+}
+
+export default function ModuleCard({ module, onStartModule }: ModuleCardProps) {
+  const buttonText = module.progress > 0 && module.progress < 100 
+    ? 'Continue' 
+    : module.isCompleted 
+    ? 'Review' 
+    : 'Start Module';
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 flex flex-col h-full transition-transform hover:scale-[1.02] hover:shadow-lg">
+      {/* Module Icon/Image */}
+      <div className="w-full h-32 mb-4 bg-gray-200 rounded-lg flex items-center justify-center">
+        {module.imageUrl ? (
+          <img 
+            src={module.imageUrl} 
+            alt={module.title}
+            className="w-full h-full object-cover rounded-lg"
+          />
+        ) : (
+          <svg 
+            className="w-16 h-16 text-gray-400" 
+            fill="none" 
+            stroke="currentColor" 
+            viewBox="0 0 24 24"
+          >
+            <path 
+              strokeLinecap="round" 
+              strokeLinejoin="round" 
+              strokeWidth={2} 
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" 
+            />
+          </svg>
+        )}
+      </div>
+
+      {/* Progress Badge */}
+      <div className="mb-2">
+        <span className="text-xs font-semibold text-gray-600 bg-[#f1bb79]/30 px-2 py-1 rounded">
+          {module.progress}% complete
+        </span>
+      </div>
+
+      {/* Module Title */}
+      <h3 className="text-xl font-bold mb-2 text-gray-800">
+        {module.title}
+      </h3>
+
+      {/* Module Description */}
+      <p className="text-sm text-gray-600 mb-4 flex-grow">
+        {module.description}
+      </p>
+
+      {/* Progress Bar */}
+      <div className="w-full bg-gray-200 rounded-full h-2 mb-4">
+        <div 
+          className="bg-[#f1bb79] h-2 rounded-full transition-all duration-300"
+          style={{ width: `${module.progress}%` }}
+        />
+      </div>
+
+      {/* Start/Continue Button */}
+      <button
+        onClick={() => onStartModule(module.id)}
+        className="w-full py-2 rounded-md bg-[#f1bb79] shadow-[3px_3px_0_#d09a58] font-bold text-lg hover:bg-[#f1bb79]/85 transition-colors flex items-center justify-center gap-2"
+      >
+        {buttonText}
+        <svg 
+          className="w-5 h-5" 
+          fill="none" 
+          stroke="currentColor" 
+          viewBox="0 0 24 24"
+        >
+          <path 
+            strokeLinecap="round" 
+            strokeLinejoin="round" 
+            strokeWidth={2} 
+            d="M9 5l7 7-7 7" 
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ModuleLandingPage.tsx
+++ b/frontend/src/components/ModuleLandingPage.tsx
@@ -7,7 +7,7 @@ import * as Form from "@radix-ui/react-form";
 const ModuleLandingPage = () => {
     const router = useRouter();
     const handleGoToModules = () => {
-        router.push("/"); //update this after module page created
+        router.push("/modules");
     };
 
     //TODO ADD VIDEO and replace placeholder

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      // Redirect to home/login page if not authenticated
+      router.push('/');
+    }
+  }, [user, loading, router]);
+
+  // Show loading state while checking authentication
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#f1bb79] mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Don't render the protected content if user is not authenticated
+  if (!user) {
+    return null;
+  }
+
+  // Render the protected content
+  return <>{children}</>;
+}

--- a/frontend/src/types/module.ts
+++ b/frontend/src/types/module.ts
@@ -1,0 +1,13 @@
+export interface Module {
+  id: string;
+  title: string;
+  description: string;
+  progress: number;
+  imageUrl?: string;
+  isCompleted?: boolean;
+}
+
+export interface ModuleCardProps {
+  module: Module;
+  onStartModule: (moduleId: string) => void;
+}


### PR DESCRIPTION
https://linear.app/gal-senior-care-foundation/issue/GAL-23/frontend-module-listing-page

Works done: 

Page displays all available training modules
Each module shows a title and brief description
Each module shows user's progress
Each module has a clear "Start Module" or "Continue" button 
Layout is organized and easy to scan (grid or list) 
Works on mobile, tablet, and desktop 
Shows loading state while modules are being fetched 
Shows helpful message if no modules are available 
Shows error message if modules fail to load

Additional Comments: 
- To test, naviagte to : http://localhost:3000/modules
- Please note that modules and progress are samples not a real data.

<img width="2856" height="1800" alt="Image 2026-01-25 at 12 07 PM" src="https://github.com/user-attachments/assets/2be987c5-e1af-419f-977a-57350c5ecb40" />

