### PR TITLE
GAL-25 Module Welcome Screen

### DIFF
--- a/frontend/src/app/modules/[moduleId]/page.tsx
+++ b/frontend/src/app/modules/[moduleId]/page.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Module } from '@/types/module';
+import ModuleWelcomeScreen from '@/components/ModuleWelcomeScreen';
+import ProtectedRoute from '@/components/ProtectedRoute';
+
+function ModuleWelcomePageContent() {
+  const router = useRouter();
+  const params = useParams();
+  const moduleId = params.moduleId as string;
+
+  const [module, setModule] = useState<Module | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchModule = async () => {
+      setLoading(true);
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      // Sample data. Replace with backend API.
+      const mockModules: Module[] = [
+          {
+            id: '1',
+            title: 'Phishing Emails',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+            objectives: [
+              'first learning objective placeholder',
+              'second learning objective placeholder',
+              'third learning objective placeholder',
+            ],
+          },
+          {
+            id: '2',
+            title: 'Bank Impersonations',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+            objectives: [
+              'first learning objective placeholder',
+              'second learning objective placeholder',
+              'third learning objective placeholder',
+            ],
+          },
+          {
+            id: '3',
+            title: 'Charity Scams',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+            objectives: [
+              'first learning objective placeholder',
+              'second learning objective placeholder',
+              'third learning objective placeholder',
+            ],
+          },
+          {
+            id: '4',
+            title: 'Computer Tech',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+            objectives: [
+              'first learning objective placeholder',
+              'second learning objective placeholder',
+              'third learning objective placeholder',
+            ],
+          },
+          {
+            id: '5',
+            title: 'Fake Survey Scams',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+            objectives: [
+              'first learning objective placeholder',
+              'second learning objective placeholder',
+              'third learning objective placeholder',
+            ],
+          },
+          {
+            id: '6',
+            title: 'Government Imposter Scam',
+            description: 'caption about phishing emails',
+            progress: 0,
+            isCompleted: false,
+            objectives: [
+              'first learning objective placeholder',
+              'second learning objective placeholder',
+              'third learning objective placeholder',
+            ],
+          },
+        ];
+
+      const found = mockModules.find(m => m.id === moduleId);
+      setModule(found || null);
+      setLoading(false);
+    };
+
+    fetchModule();
+  }, [moduleId]);
+
+  if (loading) return <div className="p-12 text-center">Loading module...</div>;
+  
+  if (!module) return <div className="p-12 text-center">Module not found</div>;
+
+  return (
+    <ModuleWelcomeScreen
+      module={module}
+      onBack={() => router.push('/modules')}
+      onNext={() => alert("This goes to the first quiz question!")}
+    />
+  );
+}
+
+export default function ModuleWelcomePage() {
+  return (
+    <ProtectedRoute>
+      <ModuleWelcomePageContent />
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/modules/page.tsx
+++ b/frontend/src/app/modules/page.tsx
@@ -82,7 +82,7 @@ function ModulesPageContent() {
   };
 
   const handleBack = () => {
-    router.back();
+    router.push('/');
   };
 
   // Loading State

--- a/frontend/src/components/ModuleWelcomeScreen.tsx
+++ b/frontend/src/components/ModuleWelcomeScreen.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Module } from '@/types/module';
+
+interface ModuleWelcomeScreenProps {
+  module: Module;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export default function ModuleWelcomeScreen({ module, onBack, onNext }: ModuleWelcomeScreenProps) {
+  return (
+    <div className="min-h-screen bg-gray-50 p-4 md:p-8 flex flex-col">
+      <div className="max-w-7xl w-full mx-auto flex flex-col flex-1">
+        {/* Back Button */}
+        <div className="mb-8">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-2 px-4 py-2 bg-white rounded-lg shadow-md hover:bg-gray-50 transition-colors cursor-pointer"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back
+          </button>
+        </div>
+
+        {/* Title and description */}
+        <div className="w-full">
+          <h1 className="text-2xl md:text-4xl font-bold mb-6 md:mb-8 break-words">
+            Welcome to the {module.title} Module!
+          </h1>
+          
+          <p className="text-base md:text-lg black mb-6 md:mb-8">
+            {module.description}
+          </p>
+
+          {/* Optional learning objectives */}
+          {module.objectives && module.objectives.length > 0 && (
+            <div className="mb-10 md:mb-16">
+              <h2 className="text-lg md:text-xl font-semibold mb-2">Learning Objectives</h2>
+              <ul className="list-disc list-inside black">
+                {module.objectives.map((obj, idx) => (
+                  <li key={idx}>{obj}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Bottom section */}
+        <div className="flex flex-col md:flex-row items-center justify-between mt-12 gap-6 pb-8">
+          <h2 className="text-lg md:text-2xl font-semibold text-left max-w-2xl mb-4 md:mb-0 md:-mt-45">
+            Let&apos;s get started protecting yourself online: one step at a time!
+          </h2>
+          <button
+            onClick={onNext}
+            className="flex items-center gap-2 px-8 py-3 bg-[#f1bb79] text-black rounded-lg shadow-[3px_3px_0_#d09a58] font-bold text-lg hover:bg-[#f1bb79]/85 transition-colors cursor-pointer whitespace-nowrap"
+          >
+            Next
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/module.ts
+++ b/frontend/src/types/module.ts
@@ -5,6 +5,7 @@ export interface Module {
   progress: number;
   imageUrl?: string;
   isCompleted?: boolean;
+  objectives?: string[];
 }
 
 export interface ModuleCardProps {


### PR DESCRIPTION
### Changes made:
- Created src/components/WelcomeModuleScreen.tsx
  - Includes back button which navigates back to modules list
  - Includes dynamic title depending on the title of the module
  - Includes description
  - Includes optional learning objectives
  - Also includes a Next button as displayed on Figma, doesn't navigate to anywhere, just gives an alert for now
- Created src/app/modules/[moduleId]/page.tsx
  - Includes dynamic routing to capture moduleId from the URL
    - because handleStartModule function in src/app/modules/page.tsx pushes to URL with moduleId
  - Includes logic to find specific module data, and renders ModuleWelcomeScreen component with the data
  - Loading screen needs change?
- Altered src/app/modules/page.tsx
  - Updated back button function so it navigates to home page
  - router.back() was navigating to module welcome screens even after I exited from them
    - For example, if I go to the "Phishing Emails" module welcome screen, then click back to "Pick a module!" page, then click Back button again, it takes me to "Phishing Emails" module rather than the home screen
- Altered src/types/module.ts
  - Added objectives field to the Module interface to store learning objectives for modules and display them in the respective module welcome screen
---
### Example Welcome Screen:
<img width="1469" height="827" alt="Screenshot 2026-02-15 at 7 11 33 AM" src="https://github.com/user-attachments/assets/ff35f65c-c38d-4315-9cc8-a2810cc1a0e4" />