### PR TITLE
GAL-31 Slide Layout Components

### DIFF
--- a/frontend/src/components/slides/SlideRenderer.tsx
+++ b/frontend/src/components/slides/SlideRenderer.tsx
@@ -1,0 +1,48 @@
+import type { SlideContent } from "@backend/types";
+
+// Import slide layout components
+import TitleBodySlide from "./TitleBodySlide";
+import TitleBodyTipSlide from "./TitleBodyTipSlide";
+import TitleBodyPointFormSlide from "./TitleBodyPointFormSlide";
+import TitleExampleTextSlide from "./TitleExampleTextSlide";
+import TitleExampleTextImageSlide from "./TitleExampleTextImageSlide";
+import TitleCaseStudySlide from "./TitleCaseStudySlide";
+import TitleQuickGuideSlide from "./TitleQuickGuideSlide";
+
+interface SlideRendererProps {
+  content: SlideContent;
+}
+
+export default function SlideRenderer({ content }: SlideRendererProps) {
+  // Render the correct component based on the layoutType
+  switch (content.layoutType) {
+    case "title_body":
+      return <TitleBodySlide content={content} />;
+
+    case "title_body_tip":
+      return <TitleBodyTipSlide content={content} />;
+      
+    case "title_body_point_form":
+      return <TitleBodyPointFormSlide content={content} />;
+      
+    case "title_example_text":
+      return <TitleExampleTextSlide content={content} />;
+      
+    case "title_example_text_image":
+      return <TitleExampleTextImageSlide content={content} />;
+      
+    case "title_case_study":
+      return <TitleCaseStudySlide content={content} />;
+      
+    case "title_quick_guide":
+      return <TitleQuickGuideSlide content={content} />;
+      
+    default:
+      // Unknown layoutType
+      return (
+        <div className="flex h-full w-full items-center justify-center text-red-500 font-bold p-8 text-center bg-gray-50 border border-red-200">
+          Error: The layoutType provided to SlideRenderer.tsx doesn't exist.
+        </div>
+      );
+  }
+}

--- a/frontend/src/components/slides/TitleBodyPointFormSlide.tsx
+++ b/frontend/src/components/slides/TitleBodyPointFormSlide.tsx
@@ -1,0 +1,35 @@
+import type { SlideContent } from "@backend/types";
+
+// Extract matching slide content
+type TitleBodyPointFormSlideContent = Extract<SlideContent, { layoutType: "title_body_point_form" }>;
+
+interface TitleBodyPointFormSlideProps {
+  content: TitleBodyPointFormSlideContent;
+}
+
+export default function TitleBodyPointFormSlide({ content }: TitleBodyPointFormSlideProps) {
+  return (
+    <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
+      {/* Page Title */}
+      <h1 className="text-4xl md:text-[44px] font-bold text-gray-900 mb-10">
+        {content.title}
+      </h1>
+
+      {/* Body Text (Point Form) */}
+      <div className="text-lg text-gray-800 flex-1">
+        {content.points && content.points.length > 0 ? (
+          <ul className="list-disc pl-6 space-y-4">
+            {content.points.map((point, index) => (
+              <li key={index} className="leading-relaxed">
+                {point}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      
+      {/* Spacer to align properly with other slides */}
+      <div className="mb-24"></div>
+    </div>
+  );
+}

--- a/frontend/src/components/slides/TitleBodySlide.tsx
+++ b/frontend/src/components/slides/TitleBodySlide.tsx
@@ -1,0 +1,45 @@
+import type { SlideContent } from "@backend/types";
+
+// Extract matching slide content
+type TitleBodySlideContent = Extract<SlideContent, { layoutType: "title_body" }>;
+
+interface TitleBodySlideProps {
+  content: TitleBodySlideContent;
+}
+
+export default function TitleBodySlide({ content }: TitleBodySlideProps) {
+  // Parsing bullet point text
+  const bulletItems = content.body
+    .split("\n")
+    .map((line) => line.replace(/^[•\-\s]+/, "").trim())
+    .filter(Boolean);
+
+  return (
+    <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
+      {/* Page Title */}
+      <h1 className="text-4xl md:text-[44px] font-bold text-gray-900 mb-10">
+        {content.title}
+      </h1>
+
+      {/* Body Text as list (or fallback to standard paragraph of text) */}
+      <div className="text-lg text-gray-800 flex-1">
+        {bulletItems.length > 0 ? (
+          <ul className="list-disc pl-6 space-y-3">
+            {bulletItems.map((item, index) => (
+              <li key={`${item}-${index}`}>{item}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="whitespace-pre-wrap leading-relaxed">{content.body}</p>
+        )}
+      </div>
+
+      {/* H2 - Caption (Optional) */}
+      {content.caption && (
+        <h2 className="text-[22px] md:text-[24px] font-bold text-gray-900 mt-12 mb-24">
+          {content.caption}
+        </h2>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/slides/TitleBodySlide.tsx
+++ b/frontend/src/components/slides/TitleBodySlide.tsx
@@ -8,12 +8,6 @@ interface TitleBodySlideProps {
 }
 
 export default function TitleBodySlide({ content }: TitleBodySlideProps) {
-  // Parsing bullet point text
-  const bulletItems = content.body
-    .split("\n")
-    .map((line) => line.replace(/^[•\-\s]+/, "").trim())
-    .filter(Boolean);
-
   return (
     <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
       {/* Page Title */}
@@ -21,17 +15,9 @@ export default function TitleBodySlide({ content }: TitleBodySlideProps) {
         {content.title}
       </h1>
 
-      {/* Body Text as list (or fallback to standard paragraph of text) */}
+      {/* Body Text as paragraph */}
       <div className="text-lg text-gray-800 flex-1">
-        {bulletItems.length > 0 ? (
-          <ul className="list-disc pl-6 space-y-3">
-            {bulletItems.map((item, index) => (
-              <li key={`${item}-${index}`}>{item}</li>
-            ))}
-          </ul>
-        ) : (
-          <p className="whitespace-pre-wrap leading-relaxed">{content.body}</p>
-        )}
+        <p className="whitespace-pre-wrap leading-relaxed">{content.body}</p>
       </div>
 
       {/* H2 - Caption (Optional) */}

--- a/frontend/src/components/slides/TitleBodyTipSlide.tsx
+++ b/frontend/src/components/slides/TitleBodyTipSlide.tsx
@@ -1,0 +1,34 @@
+import type { SlideContent } from "@backend/types";
+
+// Extract matching slide content
+type TitleBodyTipSlideContent = Extract<SlideContent, { layoutType: "title_body_tip" }>;
+
+interface TitleBodyTipSlideProps {
+  content: TitleBodyTipSlideContent;
+}
+
+export default function TitleBodyTipSlide({ content }: TitleBodyTipSlideProps) {
+  return (
+    <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
+      {/* Page Title */}
+      <h1 className="text-4xl md:text-[44px] font-bold text-gray-900 mb-10">
+        {content.title}
+      </h1>
+
+      {/* Body Text - Paragraph */}
+      <div className="text-lg text-gray-800 flex-1">
+        <p className="whitespace-pre-wrap leading-relaxed">{content.body}</p>
+      </div>
+
+      {/* Tip Section */}
+      <div className="mt-12 mb-24 flex flex-col gap-2">
+        <h2 className="text-2xl md:text-[24px] font-bold text-gray-900">
+          {content.tipTitle}
+        </h2>
+        <p className="text-lg text-gray-800 whitespace-pre-wrap leading-relaxed">
+          {content.tipText}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/slides/TitleCaseStudySlide.tsx
+++ b/frontend/src/components/slides/TitleCaseStudySlide.tsx
@@ -1,0 +1,47 @@
+import type { SlideContent } from "@backend/types";
+
+// Extract matching slide content
+type TitleCaseStudySlideContent = Extract<SlideContent, { layoutType: "title_case_study" }>;
+
+interface TitleCaseStudySlideProps {
+  content: TitleCaseStudySlideContent;
+}
+
+export default function TitleCaseStudySlide({ content }: TitleCaseStudySlideProps) {
+  return (
+    <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
+      {/* Page Title */}
+      <h1 className="text-4xl md:text-[44px] font-bold text-gray-900 mb-10">
+        {content.title}
+      </h1>
+
+      {/* Case Study Content Wrapper */}
+      <div className="flex-1 flex flex-col gap-10">
+        
+        {/* Body Text (Caption) */}
+        <div className="text-lg text-gray-800">
+          <p className="whitespace-pre-wrap leading-relaxed max-w-4xl">
+            {content.caption}
+          </p>
+        </div>
+
+        {/* Body Text (Point Form) */}
+        <div className="text-lg text-gray-800">
+          {content.points && content.points.length > 0 ? (
+            <ul className="list-disc pl-6 space-y-4 max-w-4xl">
+              {content.points.map((point, index) => (
+                <li key={index} className="leading-relaxed">
+                  {point}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+
+      </div>
+
+      {/* Spacer to align properly with other slides */}
+      <div className="mb-24"></div>
+    </div>
+  );
+}

--- a/frontend/src/components/slides/TitleExampleTextImageSlide.tsx
+++ b/frontend/src/components/slides/TitleExampleTextImageSlide.tsx
@@ -1,0 +1,52 @@
+import type { SlideContent } from "@backend/types";
+
+// Extract matching slide content
+type TitleExampleTextImageSlideContent = Extract<SlideContent, { layoutType: "title_example_text_image" }>;
+
+interface TitleExampleTextImageSlideProps {
+  content: TitleExampleTextImageSlideContent;
+}
+
+export default function TitleExampleTextImageSlide({ content }: TitleExampleTextImageSlideProps) {
+  return (
+    <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
+      {/* Page Title */}
+      <h1 className="text-4xl md:text-[44px] font-bold text-gray-900 mb-6">
+        {content.title}
+      </h1>
+
+      {/* Two-Column Content Area */}
+      <div className="flex flex-col md:flex-row gap-12 md:gap-16 lg:gap-24 flex-1">
+        
+        {/* Left Column: Subtitle & Body Text */}
+        <div className="flex-1 max-w-2xl flex flex-col pt-2">
+          <h2 className="text-2xl md:text-[28px] font-bold text-gray-900 mb-6">
+            {content.subtitle}
+          </h2>
+          <div className="text-lg text-gray-800">
+            <p className="whitespace-pre-wrap leading-relaxed">
+              {content.exampleText}
+            </p>
+          </div>
+        </div>
+
+        {/* Right Column: Image Box */}
+        <div className="flex-1 flex justify-start items-start">
+          <div className="w-full max-w-[600px] aspect-[4/3] border border-gray-400 bg-white relative overflow-hidden flex items-center justify-center">
+            {content.imageUrl ? (
+              <img 
+                src={content.imageUrl} 
+                alt="Example visual" 
+                className="w-full h-full object-cover"
+              />
+            ) : null}
+          </div>
+        </div>
+
+      </div>
+
+      {/* Spacer to align properly with other slides */}
+      <div className="mb-24"></div>
+    </div>
+  );
+}

--- a/frontend/src/components/slides/TitleExampleTextSlide.tsx
+++ b/frontend/src/components/slides/TitleExampleTextSlide.tsx
@@ -1,0 +1,34 @@
+import type { SlideContent } from "@backend/types";
+
+// Extract matching slide content
+type TitleExampleTextSlideContent = Extract<SlideContent, { layoutType: "title_example_text" }>;
+
+interface TitleExampleTextSlideProps {
+  content: TitleExampleTextSlideContent;
+}
+
+export default function TitleExampleTextSlide({ content }: TitleExampleTextSlideProps) {
+  return (
+    <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
+      {/* Page Title */}
+      <h1 className="text-4xl md:text-[44px] font-bold text-gray-900 mb-6">
+        {content.title}
+      </h1>
+
+      {/* Subtitle */}
+      <h2 className="text-2xl md:text-[28px] font-bold text-gray-900 mb-6">
+        {content.subtitle}
+      </h2>
+        
+      {/* Body Text - Paragraph */}
+      <div className="text-lg text-gray-800">
+        <p className="whitespace-pre-wrap leading-relaxed">
+          {content.exampleText}
+        </p>
+      </div>
+
+      {/* Spacer to align properly with other slides */}
+      <div className="mb-24"></div>
+    </div>
+  );
+}

--- a/frontend/src/components/slides/TitleQuickGuideSlide.tsx
+++ b/frontend/src/components/slides/TitleQuickGuideSlide.tsx
@@ -1,0 +1,35 @@
+import type { SlideContent } from "@backend/types";
+
+// Extract matching slide content
+type TitleQuickGuideSlideContent = Extract<SlideContent, { layoutType: "title_quick_guide" }>;
+
+interface TitleQuickGuideSlideProps {
+  content: TitleQuickGuideSlideContent;
+}
+
+export default function TitleQuickGuideSlide({ content }: TitleQuickGuideSlideProps) {
+  return (
+    <div className="flex flex-col flex-1 h-full w-full px-8 py-10 md:px-20 md:py-16 bg-white overflow-y-auto">
+      {/* Page Title */}
+      <h1 className="text-4xl md:text-[44px] font-bold text-gray-900 mb-10">
+        {content.title}
+      </h1>
+
+      {/* Numbered Body Texts */}
+      <div className="text-lg text-gray-800 flex-1">
+        {content.points && content.points.length > 0 ? (
+          <ol className="list-decimal pl-6 space-y-8 max-w-4xl">
+            {content.points.map((point, index) => (
+              <li key={index} className="leading-relaxed pl-2">
+                {point}
+              </li>
+            ))}
+          </ol>
+        ) : null}
+      </div>
+
+      {/* Spacer to align properly with other slides */}
+      <div className="mb-24"></div>
+    </div>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@backend/*": ["../backend/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
### Changes made:
Created 7 slide components, and SlideRenderer.tsx.

For TitleBodySlide.tsx, the body text is typed as a String in the SlideContent in backend/src/types.ts. However, in the Figma design, it is a bullet point list. I made it as a paragraph rather than a bullet point list since the type is a String rather than a String array (String [ ]).

Here is how it looks:

<img width="1469" height="827" alt="Screenshot 2026-03-15 at 12 55 33 AM" src="https://github.com/user-attachments/assets/d7184bac-ee23-4e0f-b45c-f6f7996387c8" />

&nbsp;
Everything else is implemented according to Figma design.